### PR TITLE
Check for an existing java before install.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,16 @@
 ---
+- name: Check if Java is already present
+  shell: which java
+  register: java_exists
+
 - name: Install OpenJDK JRE (headless)
   apt: pkg=openjdk-7-jre-headless={{ java_version }} state=present
+  when: not java_exists|success
 
 - name: Install OpenJDK JRE
   apt: pkg=openjdk-7-jre={{ java_version }} state=present
+  when: not java_exists|success
 
 - name: Install OpenJDK
   apt: pkg=openjdk-7-jdk={{ java_version }} state=present
+  when: not java_exists|success


### PR DESCRIPTION
This makes it easy to use, for example, Oracle Java, with other roles that depend on this role. I just set the Oracle Java role to go first.
