### PR TITLE
Add support for Oracle Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ An Ansible role for installing Java 7 JDK.
 ## Role Variables
 
 - `java_version` - Java JDK and JRE version
+- `java_flavor` - Flavor of Java to install (default: `openjdk` but can also be
+  `oracle`)
+- `java_oracle_accept_license_agreement` - Flag to accept the Oracle license agreement (default: `False`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 java_version: "7u51-2.4.6-1ubuntu4"
+java_flavor: "openjdk"
+java_oracle_accept_license_agreement: False

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -6,4 +6,7 @@
       apt: update_cache=yes
 
   roles:
-    - { role: "azavea.java" }
+    # OpenJDK
+    - { role: "azavea.java", java_version: "7u75*" }
+    # Oracle Java
+    #- { role: "azavea.java", java_version: "7u76*", java_flavor: "oracle", java_oracle_accept_license_agreement: True }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: Install OpenJDK JRE (headless)
-  apt: pkg=openjdk-7-jre-headless={{ java_version }} state=present
+- include: "openjdk.yml"
+  when: java_flavor == "openjdk"
 
-- name: Install OpenJDK JRE
-  apt: pkg=openjdk-7-jre={{ java_version }} state=present
-
-- name: Install OpenJDK
-  apt: pkg=openjdk-7-jdk={{ java_version }} state=present
+- include: "oracle.yml"
+  when: java_flavor == "oracle"

--- a/tasks/openjdk.yml
+++ b/tasks/openjdk.yml
@@ -1,0 +1,12 @@
+---
+- name: Install OpenJDK JRE (headless)
+  apt: pkg=openjdk-7-jre-headless={{ java_version }} state=present
+
+- name: Install OpenJDK JRE
+  apt: pkg=openjdk-7-jre={{ java_version }} state=present
+
+- name: Install OpenJDK
+  apt: pkg=openjdk-7-jdk={{ java_version }} state=present
+
+- name: Set OpenJDK as the default
+  alternatives: name=java path="/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java"

--- a/tasks/oracle.yml
+++ b/tasks/oracle.yml
@@ -1,0 +1,16 @@
+---
+- name: Configure the WebUpd8 repository
+  apt_repository: repo="ppa:webupd8team/java" state=present
+
+- name: Accept Oracle license
+  debconf: name=oracle-java7-installer
+           question="shared/accepted-oracle-license-v1-1"
+           value="true"
+           vtype="select"
+  when: java_oracle_accept_license_agreement
+
+- name: Install Oracle Java
+  apt: pkg=oracle-java7-installer={{ java_version }} state=present
+
+- name: Set Oracle Java as the default
+  alternatives: name=java path="/usr/lib/jvm/java-7-oracle/jre/bin/java"


### PR DESCRIPTION
This changeset adds support for installing Oracle Java via the WebUpd8 PPA.

Users of the role will have to explicitly set `java_flavor` to `oracle` and accept the Oracle license by setting `java_oracle_accept_license_agreement` to `True`.
