### PR TITLE
Add support for specifying major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ansible-java
 
-An Ansible role for installing Java 7 JDK.
+An Ansible role for installing Java.
 
 ## Role Variables
 
 - `java_version` - Java JDK and JRE version
-- `java_flavor` - Flavor of Java to install (default: `openjdk` but can also be
-  `oracle`)
+- `java_major_version` - Major version of Java to install (default: `7`)
+- `java_flavor` - Flavor of Java to install (default: `openjdk` but can also be `oracle`)
 - `java_oracle_accept_license_agreement` - Flag to accept the Oracle license agreement (default: `False`)
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 java_version: "7u51-2.4.6-1ubuntu4"
+java_major_version: "7"
 java_flavor: "openjdk"
 java_oracle_accept_license_agreement: False

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -6,7 +6,10 @@
       apt: update_cache=yes
 
   roles:
-    # OpenJDK
+    # OpenJDK 7
     - { role: "azavea.java", java_version: "7u75*" }
-    # Oracle Java
+    # OpenJDK 8 does not exist in the supported platforms of this role
+    # Oracle Java 7
     #- { role: "azavea.java", java_version: "7u76*", java_flavor: "oracle", java_oracle_accept_license_agreement: True }
+    # Oracle Java 8
+    #- { role: "azavea.java", java_major_version: "8", java_version: "8u31*", java_flavor: "oracle", java_oracle_accept_license_agreement: True }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Hector Castro
-  description: An Ansible role for installing Java 7 JDK.
+  description: An Ansible role for installing Java.
   company: Azavea Inc.
   license: Apache
   min_ansible_version: 1.2

--- a/tasks/openjdk.yml
+++ b/tasks/openjdk.yml
@@ -1,12 +1,15 @@
 ---
 - name: Install OpenJDK JRE (headless)
-  apt: pkg=openjdk-7-jre-headless={{ java_version }} state=present
+  apt: pkg=openjdk-{{ java_major_version }}-jre-headless={{ java_version }}
+       state=present
 
 - name: Install OpenJDK JRE
-  apt: pkg=openjdk-7-jre={{ java_version }} state=present
+  apt: pkg=openjdk-{{ java_major_version }}-jre={{ java_version }}
+       state=present
 
 - name: Install OpenJDK
-  apt: pkg=openjdk-7-jdk={{ java_version }} state=present
+  apt: pkg=openjdk-{{ java_major_version }}-jdk={{ java_version }}
+       state=present
 
 - name: Set OpenJDK as the default
-  alternatives: name=java path="/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java"
+  alternatives: name=java path="/usr/lib/jvm/java-{{ java_major_version }}-openjdk-amd64/jre/bin/java"

--- a/tasks/oracle.yml
+++ b/tasks/oracle.yml
@@ -3,14 +3,15 @@
   apt_repository: repo="ppa:webupd8team/java" state=present
 
 - name: Accept Oracle license
-  debconf: name=oracle-java7-installer
+  debconf: name=oracle-java{{ java_major_version }}-installer
            question="shared/accepted-oracle-license-v1-1"
            value="true"
            vtype="select"
   when: java_oracle_accept_license_agreement
 
 - name: Install Oracle Java
-  apt: pkg=oracle-java7-installer={{ java_version }} state=present
+  apt: pkg=oracle-java{{ java_major_version }}-installer={{ java_version }}
+       state=present
 
 - name: Set Oracle Java as the default
-  alternatives: name=java path="/usr/lib/jvm/java-7-oracle/jre/bin/java"
+  alternatives: name=java path="/usr/lib/jvm/java-{{ java_major_version }}-oracle/jre/bin/java"


### PR DESCRIPTION
This changeset adds support for specifying the Java major version number via `java_major_version`. This attribute defaults to `7`.
