### PR TITLE
Added ability to get latest jdk instead of specific version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+- Add support for setting the version to "latest", which will leave off the specific java version in `apt-get` installs.
+
 ## 0.2.1
 
 - Add support for supplying a major Java version to install via `java_major_version`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Ansible role for installing Java.
 
 ## Role Variables
 
-- `java_version` - Java JDK and JRE version
+- `java_version` - Java JDK and JRE version. When set to `latest`, this role will install the latest version through `apt`
 - `java_major_version` - Major version of Java to install (default: `7`)
 - `java_flavor` - Flavor of Java to install (default: `openjdk` but can also be `oracle`)
 - `java_oracle_accept_license_agreement` - Flag to accept the Oracle license agreement (default: `False`)

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -7,7 +7,7 @@
 
   roles:
     # OpenJDK 7
-    - { role: "azavea.java", java_version: "7u75*" }
+    - { role: "azavea.java", java_version: "latest" }
     # OpenJDK 8 does not exist in the supported platforms of this role
     # Oracle Java 7
     #- { role: "azavea.java", java_version: "7u76*", java_flavor: "oracle", java_oracle_accept_license_agreement: True }

--- a/tasks/openjdk.yml
+++ b/tasks/openjdk.yml
@@ -2,14 +2,33 @@
 - name: Install OpenJDK JRE (headless)
   apt: pkg=openjdk-{{ java_major_version }}-jre-headless={{ java_version }}
        state=present
+  when: java_version != "latest"
+
+- name: Install OpenJDK JRE (headless)
+  apt: pkg=openjdk-{{ java_major_version }}-jre-headless
+       state=present
+  when: java_version == "latest"
 
 - name: Install OpenJDK JRE
   apt: pkg=openjdk-{{ java_major_version }}-jre={{ java_version }}
        state=present
+  when: java_version != "latest"
+
+- name: Install OpenJDK JRE
+  apt: pkg=openjdk-{{ java_major_version }}-jre
+       state=present
+  when: java_version == "latest"
 
 - name: Install OpenJDK
   apt: pkg=openjdk-{{ java_major_version }}-jdk={{ java_version }}
        state=present
+  when: java_version != "latest"
+
+- name: Install OpenJDK
+  apt: pkg=openjdk-{{ java_major_version }}-jdk
+       state=present
+  when: java_version == "latest"
+
 
 - name: Set OpenJDK as the default
   alternatives: name=java path="/usr/lib/jvm/java-{{ java_major_version }}-openjdk-amd64/jre/bin/java"

--- a/tasks/oracle.yml
+++ b/tasks/oracle.yml
@@ -12,6 +12,12 @@
 - name: Install Oracle Java
   apt: pkg=oracle-java{{ java_major_version }}-installer={{ java_version }}
        state=present
+  when: java_version != "latest"
+
+- name: Install Oracle Java
+  apt: pkg=oracle-java{{ java_major_version }}-installer
+       state=present
+  when: java_version == "latest"
 
 - name: Set Oracle Java as the default
   alternatives: name=java path="/usr/lib/jvm/java-{{ java_major_version }}-oracle/jre/bin/java"


### PR DESCRIPTION
This is an attempt to get around the annoying moving target that is the package version number in the apt repository. So if we set version = "latest", we'll just get the latest version of the packages in the apt repository for that major java version.
