### PR TITLE
Update JDK version to current Ubuntu default.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-java_version: "7u51-2.4.6-1ubuntu4"
+java_version: "7u79-*"
 java_major_version: "7"
 java_flavor: "openjdk"
 java_oracle_accept_license_agreement: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing Java.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.2
+  min_ansible_version: 1.8
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
OpenJDK had a security update in late July. This brings us up to date.
