### PR TITLE
Update default to 7u101

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-java_version: "7u95-*"
+java_version: "7u101-*"
 java_major_version: "7"
 java_flavor: "openjdk"
 java_oracle_accept_license_agreement: False


### PR DESCRIPTION
7u95 is no longer available due to a security update.
