### PR TITLE
Feature/tnation/openjdk 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Ansible role for installing Java.
 ## Role Variables
 
 - `java_version` - Java JDK and JRE version
-- `java_major_version` - Major version of Java to install (default: `7`)
+- `java_major_version` - Major version of Java to install (default: `8`)
 - `java_flavor` - Flavor of Java to install (default: `openjdk` but can also be `oracle`)
 - `java_oracle_accept_license_agreement` - Flag to accept the Oracle license agreement (default: `False`)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-java_version: "7u101-*"
-java_major_version: "7"
+java_version: "8u141*"
+java_major_version: "8"
 java_flavor: "openjdk"
 java_oracle_accept_license_agreement: False

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,7 +1,7 @@
 ---
 ansible:
   config_file: ansible.cfg
-  sudo: True
+  become: True
 
 vagrant:
   platforms:

--- a/playbook.yml
+++ b/playbook.yml
@@ -11,6 +11,7 @@
     - name: Check ubuntu release
       raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
       register: ubuntu_release
+      changed_when: False
 
     - debug: msg="Running ubuntu version {{ ubuntu_release.stdout|float }}"
 
@@ -20,11 +21,14 @@
     - name: Update APT cache
       raw: apt-get update
       become: True
+      changed_when: False
+
 
     - name: Install python
       raw: apt-get install -yq python
       become: True
       when: "{{ ubuntu_release.stdout | version_compare('16.04', '>=') }}"
+      changed_when: False
 
     # Gather facts once ansible dependencies are installed
     - name: Gather facts

--- a/playbook.yml
+++ b/playbook.yml
@@ -31,14 +31,8 @@
       setup:
 
   roles:
-    # OpenJDK 7, all Defaults
-    - { role: "ansible-java",
-        when:
-          "{{ ansible_distribution_version | version_compare('16.04','<') }}" }
-
-    - { role: "ansible-java", java_major_version: "8", java_version: "8u91*",
-        when:
-          "{{ ansible_distribution_version | version_compare('16.04','>=') }}" }
+    # OpenJDK 8, all Defaults
+    - { role: "ansible-java" }
 
     # version override for 14.04
     # - { role: "ansible-java", java_version: "7u51*",

--- a/tasks/openjdk.yml
+++ b/tasks/openjdk.yml
@@ -1,4 +1,8 @@
 ---
+- name: Add OpenJDK PPA
+  apt_repository: repo='ppa:openjdk-r/ppa'
+  when: "{{ ansible_distribution_version | version_compare('14.04', '=') and java_major_version | version_compare('8', '>=') }}"
+
 - name: Install OpenJDK JRE (headless)
   apt: pkg=openjdk-{{ java_major_version }}-jre-headless={{ java_version }}
        state=present


### PR DESCRIPTION
Install `openjdk-8` via PPA on Ubuntu Trusty, and set the default `java_major_version` to 8. Additionally, update the molecule config so that tests pass.

# Testing
Ensure `molecule --version` is 1.25.0, and run `molecule test`. Ensure all tests pass. 

Fixes #22 