### PR TITLE
Fix Jinja template warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # Ansible
 *.retry
+*.pyc

--- a/playbook.yml
+++ b/playbook.yml
@@ -36,25 +36,22 @@
 
   roles:
     # OpenJDK 8, all Defaults
-    - { role: "ansible-java" }
+    - role: "ansible-java"
+      when: ansible_distribution_version | version_compare('16.04', '<')
 
-    # version override for 14.04
-    # - { role: "ansible-java", java_version: "7u51*",
-    #     when:
-    #     "{{ ansible_distribution_version | version_compare('16.04','<') }}" }
+    # Version override for 16.04
+    - role: "ansible-java"
+      java_version: "8u131*"
+      when: ansible_distribution_version | version_compare("16.04", ">=")
 
-    # version override for 16.04
-    # - { role: "ansible-java", java_version: "8u77*",
-    #     java_major_version: "8",
-    #     when:
-    #     "{{ ansible_distribution_version | version_compare('16.04','>=') }}" }
+    # Java_version override
+    # - role: "ansible-java"
+    #   java_version: "8u44*"
+    #   when: ansible_distribution_version | version_compare('16.04','<')
 
-    # Java_major_version override for 14.04
-    # - { role: "ansible-java", java_version: "6u39*", java_major_version: "6",
-    #     when:
-    #     "{{ ansible_distribution_version | version_compare('16.04','<') }}" }
 
-    # Java_major_version override for 16.04
-    # - { role: "ansible-java", java_version: "9*", java_major_version: "9",
-    #     when:
-    #     "{{ ansible_distribution_version | version_compare('16.04','>=') }}" }
+    # Java_major_version override
+    # - role: "ansible-java"
+    #   java_version: "9*"
+    #   java_major_version: 9
+    #   when: ansible_distribution_version | version_compare('16.04','<')

--- a/playbook.yml
+++ b/playbook.yml
@@ -27,7 +27,7 @@
     - name: Install python
       raw: apt-get install -yq python
       become: True
-      when: "{{ ubuntu_release.stdout | version_compare('16.04', '>=') }}"
+      when: ubuntu_release.stdout | version_compare('16.04', '>=')
       changed_when: False
 
     # Gather facts once ansible dependencies are installed

--- a/tasks/openjdk.yml
+++ b/tasks/openjdk.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add OpenJDK PPA
   apt_repository: repo='ppa:openjdk-r/ppa'
-  when: "{{ ansible_distribution_version | version_compare('14.04', '=') and java_major_version | version_compare('8', '>=') }}"
+  when: ansible_distribution_version | version_compare('14.04', '=') and java_major_version | version_compare('8', '>=')
 
 - name: Install OpenJDK JRE (headless)
   apt: pkg=openjdk-{{ java_major_version }}-jre-headless={{ java_version }}

--- a/tasks/openjdk.yml
+++ b/tasks/openjdk.yml
@@ -1,20 +1,7 @@
 ---
 - name: Add OpenJDK PPA
   apt_repository: repo='ppa:openjdk-r/ppa'
-  when: ansible_distribution_version | version_compare('14.04', '=') and java_major_version | version_compare('8', '>=')
-
-- name: Install OpenJDK JRE (headless)
-  apt: pkg=openjdk-{{ java_major_version }}-jre-headless={{ java_version }}
-       state=present
-
-- name: Install OpenJDK (headless)
-  apt: pkg=openjdk-{{ java_major_version }}-jdk-headless={{ java_version }}
-       state=present
-  when: java_major_version | version_compare('8', '>=')
-
-- name: Install OpenJDK JRE
-  apt: pkg=openjdk-{{ java_major_version }}-jre={{ java_version }}
-       state=present
+  when: ansible_distribution_version | version_compare('16.04', '<') and java_major_version | version_compare('8', '>=')
 
 - name: Install OpenJDK
   apt: pkg=openjdk-{{ java_major_version }}-jdk={{ java_version }}


### PR DESCRIPTION
# Overview 
- Remove Jinja2 template delimiters from `when` statements, which makes Ansible throw warnings:

```bash
TASK [Install python] **********************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ ubuntu_release.stdout |
version_compare('16.04', '>=') }}

skipping: [ansible-java]

TASK [Gather facts] ************************************************************
ok: [ansible-java]

TASK [ansible-java : Add OpenJDK PPA] ******************************************
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ ansible_distribution_version |
version_compare('14.04', '=') and java_major_version | version_compare('8',
'>=') }}
```

- Stop manually installing OpenJDK dependencies, since they are installed when the `openjdk-*-jdk` package is installed.
- Update the `roles` section format of `playbook.yml`.

# Testing
- Run `molecule test --platform=all`, ensure all tests pass.