### PR TITLE
Install CA Certificates after installing OpenJDK

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: Reload ldconfig
   command: "ldconfig"
+
+- name: Install SSL certificates
+  command: /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/tasks/openjdk.yml
+++ b/tasks/openjdk.yml
@@ -6,6 +6,7 @@
 - name: Install OpenJDK
   apt: pkg=openjdk-{{ java_major_version }}-jdk={{ java_version }}
        state=present
+  notify: Install SSL certificates
 
 - name: Determine if 64bit architecture
   set_fact:

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -2,3 +2,7 @@ def test_java_exists(Command):
     version_result = Command("java -version")
 
     assert version_result.rc == 0
+
+
+def test_java_certs_exist(File):
+    assert File("/etc/ssl/certs/java/cacerts").exists


### PR DESCRIPTION
Fixes a `ca-certificates-java` bug where installing OpenJDK does not install Java SSL certificates.

Closes #26 
Connects WikiWatershed/model-my-watershed#2167
# Testing
- Follow the testing instructions in the `README`, make sure molecule tests pass.
- It also may be worthwhile to test this on WikiWatershed/model-my-watershed#2167. To do so, apply this diff to your MMW branch, and re-provision the worker VM:

```diff
diff --git a/deployment/ansible/roles.yml b/deployment/ansible/roles.yml
index 714c97a8..73ca45ca 100644
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -44,7 +44,10 @@
   version: 0.1.0
 - src: azavea.beaver
   version: 1.0.1
-- src: azavea.java
-  version: 0.5.0
+
+- name: azavea.java 
+  src: git+https://github.com/azavea/ansible-java.git
+  version: origin/feature/tnation/install-cacerts
+  
 - src: azavea.docker
   version: 1.0.2
diff --git a/vagrant/ansible_galaxy_helper.rb b/vagrant/ansible_galaxy_helper.rb
index 6e14f858..ad95257d 100644
--- a/vagrant/ansible_galaxy_helper.rb
+++ b/vagrant/ansible_galaxy_helper.rb
@@ -18,7 +18,7 @@ module AnsibleGalaxyHelper
     ansible_roles_spec = File.join(ansible_directory, "roles.yml")
 
     YAML.load_file(ansible_roles_spec).each do |role|
-      role_name = role["src"]
+      role_name = role["name"] ? role["name"] : role["src"]
       role_version = role["version"]      
       role_path = File.join(ansible_directory, "roles", role_name)
       galaxy_metadata = galaxy_install_info(role_path)
```