### PR TITLE
Update README; use requirements file for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,12 @@ An Ansible role for installing Java.
 - `java_oracle_accept_license_agreement` - Flag to accept the Oracle license agreement (default: `False`)
 
 ## Testing
-Tests are done using [molecule](http://molecule.readthedocs.io/). To run the test suite, install molecule and its dependencies and run ` molecule test` from the folder containing molecule.yml. To add additional tests, add a [testinfra](http://testinfra.readthedocs.org/) python script in the [tests](./tests/) directory, or add a function to [test_java.py](./tests/test_java.py). Information about available Testinfra modules is available [here](http://testinfra.readthedocs.io/en/latest/modules.html).
 
-### Example 
+Tests are driven by [Molecule](http://molecule.readthedocs.io/). To run the test suite, install Molecule and run ` molecule test` from the folder containing `molecule.yml`. To add additional tests, add a [testinfra](http://testinfra.readthedocs.org/) Python script in the [tests](./tests/) directory, or add a function to [test_java.py](./tests/test_java.py). Information about available Testinfra modules is available [here](http://testinfra.readthedocs.io/en/latest/modules.html).
+
+### Usage
+
 ```
-# Download molecule, dependencies
-$ pip install molecule
-
-# Change to the top-level project directory, which contains molecule.yml
-$ cd /path/to/ansible-java
-
-# Ensure that molecule.yml is present
-$ ls
-CHANGELOG.md                             molecule.yml
-LICENSE                                  playbook.retry
-README.md                                playbook.yml
-ansible.cfg                              tasks
-defaults                                 templates
-handlers                                 tests
-meta                                     
-
-# We're in the right directory, so let's run tests!
+$ pip install -r requirements.txt
 $ molecule test
-
 ```

--- a/molecule.yml
+++ b/molecule.yml
@@ -3,6 +3,14 @@ ansible:
   config_file: ansible.cfg
   become: True
 
+molecule:
+  test:
+    sequence:
+      - destroy
+      - syntax
+      - create
+      - converge
+
 vagrant:
   platforms:
     - name: trusty64

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+molecule==1.25
+python-vagrant>=0.5,<0.6.99


### PR DESCRIPTION
Molecule made a major release that changed its configuration file format, which makes the configuration file here incompatible. Instead of upgrading the configuration file format now (seems a bit involved), I added a `requirements.txt` with working Molecule and `python-vagrant` versions.

I also updated the `README` to include the updated installation steps.

Resolves https://github.com/azavea/ansible-java/issues/28

---

**Testing**

The following steps should allow you to successfully execute the test suite:

```bash
virtualenv .env 
$ source .env/bin/activate
(.env) $ pip install -r requirements.txt
(.env) $ molecule test
```