### PR TITLE
Execute JDK post-install script without depending on handlers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-java_version: "8u141*"
+java_version: "8u*"
 java_major_version: "8"
 java_flavor: "openjdk"
 java_oracle_accept_license_agreement: False

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,3 @@
 ---
 - name: Reload ldconfig
   command: "ldconfig"
-
-- name: Install SSL certificates
-  command: /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/molecule.yml
+++ b/molecule.yml
@@ -17,7 +17,7 @@ vagrant:
       box: ubuntu/trusty64
 
     - name: xenial64
-      box: ubuntu/xenial64
+      box: bento/ubuntu-16.04
 
   providers:
     - name: virtualbox

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,32 +3,15 @@
   gather_facts: False
 
   pre_tasks:
-
     # Check Ubuntu release version to determine if we need to install python 2,
     # an ansible dependency that isn't included by default in Ubuntu 16.04 and
     # up.
-
     - name: Check ubuntu release
       raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
       register: ubuntu_release
       changed_when: False
 
-    - debug: msg="Running ubuntu version {{ ubuntu_release.stdout|float }}"
-
-    # Update apt cache and install python 2 for Ubuntu versions greater than
-    # 16.04
-
-    - name: Update APT cache
-      raw: apt-get update
-      become: True
-      changed_when: False
-
-
-    - name: Install python
-      raw: apt-get install -yq python
-      become: True
-      when: ubuntu_release.stdout | version_compare('16.04', '>=')
-      changed_when: False
+    - debug: msg="Running Ubuntu version {{ ubuntu_release.stdout|float }}"
 
     # Gather facts once ansible dependencies are installed
     - name: Gather facts
@@ -48,7 +31,6 @@
     # - role: "ansible-java"
     #   java_version: "8u44*"
     #   when: ansible_distribution_version | version_compare('16.04','<')
-
 
     # Java_major_version override
     # - role: "ansible-java"

--- a/playbook.yml
+++ b/playbook.yml
@@ -41,7 +41,7 @@
 
     # Version override for 16.04
     - role: "ansible-java"
-      java_version: "8u131*"
+      java_version: "8u*"
       when: ansible_distribution_version | version_compare("16.04", ">=")
 
     # Java_version override

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: "openjdk.yml"
+- import_tasks: "openjdk.yml"
   when: java_flavor == "openjdk"
 
-- include: "oracle.yml"
+- import_tasks: "oracle.yml"
   when: java_flavor == "oracle"

--- a/tasks/openjdk.yml
+++ b/tasks/openjdk.yml
@@ -6,7 +6,15 @@
 - name: Install OpenJDK
   apt: pkg=openjdk-{{ java_major_version }}-jdk={{ java_version }}
        state=present
-  notify: Install SSL certificates
+
+- name: Determine if JDK CA certificates directory exists
+  stat:
+    path: /etc/ssl/certs/java/cacerts
+  register: ca_certificates_directory
+
+- name: Execute post-installation script for CA certificates
+  command: /var/lib/dpkg/info/ca-certificates-java.postinst configure
+  when: not ca_certificates_directory.stat.exists
 
 - name: Determine if 64bit architecture
   set_fact:


### PR DESCRIPTION
Using Ansible handlers to execute the JDK post-installation script (that works around a bug in the package) is failure prone because any failure in the overall Ansible run negates the execution of any queued handlers. If the event that initially queued the handle completed prior to that failure, the handler will never get queued again.

These changes make it so that a missing `/etc/ssl/certs/java/cacerts` triggers the post-installation script execution.

In addition:

- The base box for Ubuntu Xenial was updated
- Deprecation warnings caused by `include` were replaced

Fixes #33 
Fixes #34 

---

**Testing**

Execute the following command two times in a row, consecutively:

```bash
$ molecule converge
```

Ensure that the first pass triggers:

```
TASK [ansible-java : Execute post-installation script for CA certificates] *****
changed: [ansible-java]
```

Ensure that the second pass emits:

```
TASK [ansible-java : Determine if JDK CA certificates directory exists] ********
skipping: [ansible-java]

TASK [ansible-java : Execute post-installation script for CA certificates] *****
skipping: [ansible-java]
```

Afterwards, execute `molecule destroy`.

(You can test the Xenial path by adding `--platform xenial64` to `converge` and `destroy`.)